### PR TITLE
Updated marko-hapi example to hapi v17

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Marko Hapi Sample
 
-This sample application illustrates how to integrate Marko with a Hapi server.
+This sample application illustrates how to integrate Marko with a Hapi 17 server using hapi/Vision plugin.
+
+The example demonstrates how to use reusable content with *include*; and also gives an example of a MarkoJS *component* using custom tags.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This sample application illustrates how to integrate Marko with a Hapi 17 server using hapi/Vision plugin.
 
-The example demonstrates how to use reusable content with *include*; and also gives an example of a MarkoJS *component* using custom tags.
+The example demonstrates how to use reusable content with **include**; and also gives an example of a MarkoJS **component** using custom tags.
 
 ## Installation
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,715 @@
+{
+  "name": "marko-hapi",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "accept": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/accept/-/accept-3.0.2.tgz",
+      "integrity": "sha512-bghLXFkCOsC1Y2TZ51etWfKDs6q249SAoHTZVfzWWdlZxoij+mgkj9AmUJWQpDY48TfnrTDIe43Xem4zdMe7mQ==",
+      "requires": {
+        "boom": "7.1.1",
+        "hoek": "5.0.2"
+      }
+    },
+    "ammo": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ammo/-/ammo-3.0.0.tgz",
+      "integrity": "sha512-6yoz9MXYV9sgCHrwprHWPxBaJ9/roQRfXzS//4JCNgKfPYcghFNwJQKBt6vWOoSGGRHsP6qsLJ+xtKStKJWdLQ==",
+      "requires": {
+        "boom": "6.0.0",
+        "hoek": "5.0.2"
+      },
+      "dependencies": {
+        "boom": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-6.0.0.tgz",
+          "integrity": "sha512-LYLa8BmiiOWjvxTMVh73lcZzd2E5yczrKvxAny1UuzO2tkarLrw4tdp3rdfmus3+YfKcZP0vRSM3Obh+fGK6eA==",
+          "requires": {
+            "hoek": "5.0.2"
+          }
+        }
+      }
+    },
+    "app-module-path": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/app-module-path/-/app-module-path-2.2.0.tgz",
+      "integrity": "sha1-ZBqlXft9am8KgUHEucCqULbCTdU="
+    },
+    "argly": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/argly/-/argly-1.2.0.tgz",
+      "integrity": "sha1-KydORVGin/XnGZ0u2XiOtm7TbmA="
+    },
+    "assertion-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
+      "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw="
+    },
+    "b64": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/b64/-/b64-4.0.0.tgz",
+      "integrity": "sha512-EhmUQodKB0sdzPPrbIWbGqA5cQeTWxYrAgNeeT1rLZWtD3tbNTnphz8J4vkXI3cPgBNlXBjzEbzDzq0Nwi4f9A=="
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "big-time": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/big-time/-/big-time-2.0.0.tgz",
+      "integrity": "sha512-OXsmBxlRLwUc65MLta2EOyMTLcjZQkxHkJ81lVPeyVqZag8zhUfKRYIbF3E/IW/LWR8kf8a1GlRYkBXKVGqJOw=="
+    },
+    "boom": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-7.1.1.tgz",
+      "integrity": "sha512-qwEARHTliqgEQiVkzKkkbLt3q0vRPIW60VRZ8zRnbjsm7INkPe9NxfAYDDYLZOdhxyUHa1gIe639Cx7t6RH/4A==",
+      "requires": {
+        "hoek": "5.0.2"
+      }
+    },
+    "bounce": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/bounce/-/bounce-1.2.0.tgz",
+      "integrity": "sha512-8syCGe8B2/WC53118/F/tFy5aW00j+eaGPXmAUP7iBhxc+EBZZxS1vKelWyBCH6IqojgS2t1gF0glH30qAJKEw==",
+      "requires": {
+        "boom": "7.1.1",
+        "hoek": "5.0.2"
+      }
+    },
+    "brace-expansion": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "browser-refresh-client": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/browser-refresh-client/-/browser-refresh-client-1.1.4.tgz",
+      "integrity": "sha1-jl/4R1/h1UHSroH3oa6gWuIaYhc="
+    },
+    "call": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/call/-/call-5.0.1.tgz",
+      "integrity": "sha512-ollfFPSshiuYLp7AsrmpkQJ/PxCi6AzV81rCjBwWhyF2QGyUY/vPDMzoh4aUcWyucheRglG2LaS5qkIEfLRh6A==",
+      "requires": {
+        "boom": "7.1.1",
+        "hoek": "5.0.2"
+      }
+    },
+    "catbox": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/catbox/-/catbox-10.0.2.tgz",
+      "integrity": "sha512-cTQTQeKMhWHU0lX8CADE3g1koGJu+AlcWFzAjMX/8P+XbkScGYw3tJsQpe2Oh8q68vOQbOLacz9k+6V/F3Z9DA==",
+      "requires": {
+        "boom": "7.1.1",
+        "bounce": "1.2.0",
+        "hoek": "5.0.2",
+        "joi": "13.1.0"
+      }
+    },
+    "catbox-memory": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/catbox-memory/-/catbox-memory-3.1.1.tgz",
+      "integrity": "sha512-fl6TI/uneeUb9NGClKWZWkpCZQrkPmuVz/Jaqqb15vqW6KGfJ/vMP/ZMp8VgAkyTrrRvFHbFcS67sbU7EkvbhQ==",
+      "requires": {
+        "big-time": "2.0.0",
+        "boom": "7.1.1",
+        "hoek": "5.0.2"
+      }
+    },
+    "chai": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
+      "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
+      "requires": {
+        "assertion-error": "1.0.2",
+        "deep-eql": "0.1.3",
+        "type-detect": "1.0.0"
+      }
+    },
+    "char-props": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/char-props/-/char-props-0.1.5.tgz",
+      "integrity": "sha1-W5UvniDqIc0Iyn/hNaEPb+kcEJ4="
+    },
+    "complain": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/complain/-/complain-1.2.0.tgz",
+      "integrity": "sha512-aP/MxFoYYVUZ8Xdih1vyaTSRiD99XLnlCloNre/UjFQFJkZ6YuMbGksi0jfxKeFOdlzm/6eE01vpJc99HiN/Mg==",
+      "requires": {
+        "error-stack-parser": "2.0.1"
+      }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "content": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/content/-/content-4.0.3.tgz",
+      "integrity": "sha512-BrMfT1xXZHaXyPT/sneXc3IQzh8uL15JWV1R5tU0xo4sBGjF7BN+IRi9WoQLSbfNEs7bJ3E69rjxBKg/RL7lOQ==",
+      "requires": {
+        "boom": "7.1.1"
+      }
+    },
+    "cryptiles": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-4.1.1.tgz",
+      "integrity": "sha512-YuQUPbcOmaZsdvxJZ25DCA1W+lLIRoPJKBDKin+St1RCYEERSfoe1d25B1MvWNHN3e8SpFSVsqYvEUjp8J9H2w==",
+      "requires": {
+        "boom": "7.1.1"
+      }
+    },
+    "deep-eql": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+      "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
+      "requires": {
+        "type-detect": "0.1.1"
+      },
+      "dependencies": {
+        "type-detect": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
+          "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI="
+        }
+      }
+    },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+    },
+    "deresolve": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/deresolve/-/deresolve-1.1.2.tgz",
+      "integrity": "sha1-nPI3nI0tYx3EuZVylLkOSnLLbOA=",
+      "requires": {
+        "lasso-package-root": "1.0.1",
+        "raptor-polyfill": "1.0.2",
+        "resolve-from": "1.0.1"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+          "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY="
+        }
+      }
+    },
+    "error-stack-parser": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.1.tgz",
+      "integrity": "sha1-oyArj7AxFKqbQKDjZp5IsrZaAQo=",
+      "requires": {
+        "stackframe": "1.0.4"
+      }
+    },
+    "escodegen": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.0.tgz",
+      "integrity": "sha512-v0MYvNQ32bzwoG2OSFzWAkuahDQHK92JBN0pTAALJ4RIxEZe766QJPDR8Hqy7XNUy5K3fnVL76OqYAdc4TZEIw==",
+      "requires": {
+        "esprima": "3.1.3",
+        "estraverse": "4.2.0",
+        "esutils": "2.0.2",
+        "optionator": "0.8.2",
+        "source-map": "0.5.7"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
+        }
+      }
+    },
+    "esprima": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
+    },
+    "estraverse": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
+    },
+    "esutils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+    },
+    "events": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+    },
+    "events-light": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/events-light/-/events-light-1.0.5.tgz",
+      "integrity": "sha1-lk5jRQugr0prAiqpVbF//vZXte4=",
+      "requires": {
+        "chai": "3.5.0"
+      }
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+    },
+    "hapi": {
+      "version": "17.2.0",
+      "resolved": "https://registry.npmjs.org/hapi/-/hapi-17.2.0.tgz",
+      "integrity": "sha512-zw2tqNimjT+qglgUNGNpeweHJ5To1xUcJcfGKsG5dWiTzwkEZtmtHJ8mBIvxuuZ3Buu4xkAGj0yWrrR95FVqQQ==",
+      "requires": {
+        "accept": "3.0.2",
+        "ammo": "3.0.0",
+        "boom": "7.1.1",
+        "bounce": "1.2.0",
+        "call": "5.0.1",
+        "catbox": "10.0.2",
+        "catbox-memory": "3.1.1",
+        "heavy": "6.1.0",
+        "hoek": "5.0.2",
+        "joi": "13.1.0",
+        "mimos": "4.0.0",
+        "podium": "3.1.2",
+        "shot": "4.0.4",
+        "statehood": "6.0.5",
+        "subtext": "6.0.7",
+        "teamwork": "3.0.1",
+        "topo": "3.0.0"
+      }
+    },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
+    },
+    "heavy": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/heavy/-/heavy-6.1.0.tgz",
+      "integrity": "sha512-TKS9DC9NOTGulHQI31Lx+bmeWmNOstbJbGMiN3pX6bF+Zc2GKSpbbym4oasNnB6yPGkqJ9TQXXYDGohqNSJRxA==",
+      "requires": {
+        "boom": "7.1.1",
+        "hoek": "5.0.2",
+        "joi": "13.1.0"
+      }
+    },
+    "hoek": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.2.tgz",
+      "integrity": "sha512-NA10UYP9ufCtY2qYGkZktcQXwVyYK4zK0gkaFSB96xhtlo6V8tKXdQgx8eHolQTRemaW0uLn8BhjhwqrOU+QLQ=="
+    },
+    "htmljs-parser": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/htmljs-parser/-/htmljs-parser-2.3.2.tgz",
+      "integrity": "sha1-HMW/mCSgkcKIILM+r3gIOo6qhWw=",
+      "requires": {
+        "char-props": "0.1.5",
+        "complain": "1.2.0"
+      }
+    },
+    "iron": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/iron/-/iron-5.0.4.tgz",
+      "integrity": "sha512-7iQ5/xFMIYaNt9g2oiNiWdhrOTdRUMFaWENUd0KghxwPUhrIH8DUY8FEyLNTTzf75jaII+jMexLdY/2HfV61RQ==",
+      "requires": {
+        "boom": "7.1.1",
+        "cryptiles": "4.1.1",
+        "hoek": "5.0.2"
+      }
+    },
+    "isemail": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.0.0.tgz",
+      "integrity": "sha512-rz0ng/c+fX+zACpLgDB8fnUQ845WSU06f4hlhk4K8TJxmR6f5hyvitu9a9JdMD7aq/P4E0XdG1uaab2OiXgHlA==",
+      "requires": {
+        "punycode": "2.1.0"
+      }
+    },
+    "items": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/items/-/items-2.1.1.tgz",
+      "integrity": "sha1-i9FtnIOxlSneWuoyGsqtp4NkoZg="
+    },
+    "joi": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-13.1.0.tgz",
+      "integrity": "sha512-x6pGmDYI6hwNi3skP6irQqRaJntzeaWmZ4rsnjc/NTlf6P5Gp3Aw/O8REe8oLJ6wPhrzd9K3RW1m3Yz/Hx4Weg==",
+      "requires": {
+        "hoek": "5.0.2",
+        "isemail": "3.0.0",
+        "topo": "3.0.0"
+      }
+    },
+    "lasso-caching-fs": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/lasso-caching-fs/-/lasso-caching-fs-1.0.2.tgz",
+      "integrity": "sha1-m+TrHwaqwSYDRMrq70LC8AhusQ0=",
+      "requires": {
+        "raptor-async": "1.1.3"
+      }
+    },
+    "lasso-modules-client": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/lasso-modules-client/-/lasso-modules-client-2.0.5.tgz",
+      "integrity": "sha1-2aBnJKkAl3Y2lxZn7pwXDS/E3Sg=",
+      "requires": {
+        "lasso-package-root": "1.0.1",
+        "raptor-polyfill": "1.0.2"
+      }
+    },
+    "lasso-package-root": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lasso-package-root/-/lasso-package-root-1.0.1.tgz",
+      "integrity": "sha1-mX0OcfQdA8Xw+gmlvCmNeW+LLCM=",
+      "requires": {
+        "lasso-caching-fs": "1.0.2"
+      }
+    },
+    "levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "requires": {
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2"
+      }
+    },
+    "listener-tracker": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/listener-tracker/-/listener-tracker-2.0.0.tgz",
+      "integrity": "sha1-OWCLQ1wJAfpVECF8FFJyjWvBm18="
+    },
+    "marko": {
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/marko/-/marko-4.7.4.tgz",
+      "integrity": "sha512-nqK2rq/fNlYo50TOFYxvVKfkzZQknu8h2IO6H5eAkloPnAFGxmCPpr9d/j5qeq2wTpYSqOV8pNYmw2mQOsJEZw==",
+      "requires": {
+        "app-module-path": "2.2.0",
+        "argly": "1.2.0",
+        "browser-refresh-client": "1.1.4",
+        "char-props": "0.1.5",
+        "complain": "1.2.0",
+        "deresolve": "1.1.2",
+        "escodegen": "1.9.0",
+        "esprima": "4.0.0",
+        "estraverse": "4.2.0",
+        "events": "1.1.1",
+        "events-light": "1.0.5",
+        "he": "1.1.1",
+        "htmljs-parser": "2.3.2",
+        "lasso-caching-fs": "1.0.2",
+        "lasso-modules-client": "2.0.5",
+        "lasso-package-root": "1.0.1",
+        "listener-tracker": "2.0.0",
+        "minimatch": "3.0.4",
+        "object-assign": "4.1.1",
+        "property-handlers": "1.1.1",
+        "raptor-json": "1.1.0",
+        "raptor-polyfill": "1.0.2",
+        "raptor-promises": "1.0.3",
+        "raptor-regexp": "1.0.1",
+        "raptor-util": "3.2.0",
+        "resolve-from": "2.0.0",
+        "shorthash": "0.0.2",
+        "simple-sha1": "2.1.0",
+        "strip-json-comments": "2.0.1",
+        "try-require": "1.2.1",
+        "warp10": "1.3.6"
+      }
+    },
+    "mime-db": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.32.0.tgz",
+      "integrity": "sha512-+ZWo/xZN40Tt6S+HyakUxnSOgff+JEdaneLWIm0Z6LmpCn5DMcZntLyUY5c/rTDog28LhXLKOUZKoTxTCAdBVw=="
+    },
+    "mimos": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimos/-/mimos-4.0.0.tgz",
+      "integrity": "sha512-JvlvRLqGIlk+AYypWrbrDmhsM+6JVx/xBM5S3AMwTBz1trPCEoPN/swO2L4Wu653fL7oJdgk8DMQyG/Gq3JkZg==",
+      "requires": {
+        "hoek": "5.0.2",
+        "mime-db": "1.32.0"
+      }
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "requires": {
+        "brace-expansion": "1.1.8"
+      }
+    },
+    "nigel": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/nigel/-/nigel-3.0.0.tgz",
+      "integrity": "sha512-ufFVFCe1zS/pfIQzQNa5uJxB8v8IcVTUn1zyPvQwb4CQGRxxBfdQPSXpEnI6ZzIwbV5L+GuAoRhYgcVSvTO7fA==",
+      "requires": {
+        "hoek": "5.0.2",
+        "vise": "3.0.0"
+      }
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+    },
+    "optionator": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "requires": {
+        "deep-is": "0.1.3",
+        "fast-levenshtein": "2.0.6",
+        "levn": "0.3.0",
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2",
+        "wordwrap": "1.0.0"
+      }
+    },
+    "pez": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pez/-/pez-4.0.1.tgz",
+      "integrity": "sha512-0c/SoW5MY7lPdc5U1Q/ixyjLZbluGWJonHVmn4mKwSq7vgO9+a9WzoCopHubIwkot6Q+fevNVElaA+1M9SqHrA==",
+      "requires": {
+        "b64": "4.0.0",
+        "boom": "7.1.1",
+        "content": "4.0.3",
+        "hoek": "5.0.2",
+        "nigel": "3.0.0"
+      }
+    },
+    "podium": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/podium/-/podium-3.1.2.tgz",
+      "integrity": "sha512-18VrjJAduIdPv7d9zWsfmKxTj3cQTYC5Pv5gtKxcWujYBpGbV+mhNSPYhlHW5xeWoazYyKfB9FEsPT12r5rY1A==",
+      "requires": {
+        "hoek": "5.0.2",
+        "joi": "13.1.0"
+      }
+    },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
+    },
+    "property-handlers": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/property-handlers/-/property-handlers-1.1.1.tgz",
+      "integrity": "sha1-yyDTIqq32U//rCj0bJGGvVlHtLQ="
+    },
+    "punycode": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
+      "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0="
+    },
+    "q": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
+    },
+    "raptor-async": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/raptor-async/-/raptor-async-1.1.3.tgz",
+      "integrity": "sha1-uDw8m2A9yYXCw6n3jStAc+b2Akw="
+    },
+    "raptor-json": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/raptor-json/-/raptor-json-1.1.0.tgz",
+      "integrity": "sha1-cL0JsU5k99MuxQzOg3fWApwPCHY=",
+      "requires": {
+        "raptor-strings": "1.0.2"
+      }
+    },
+    "raptor-polyfill": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/raptor-polyfill/-/raptor-polyfill-1.0.2.tgz",
+      "integrity": "sha1-ZXW852JUDYRAVtcc7xFmJIj1E+0="
+    },
+    "raptor-promises": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/raptor-promises/-/raptor-promises-1.0.3.tgz",
+      "integrity": "sha1-1XaxEOBCNlT3/fFyHijULk3DwOs=",
+      "requires": {
+        "q": "1.5.1",
+        "raptor-util": "1.1.2"
+      },
+      "dependencies": {
+        "raptor-util": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/raptor-util/-/raptor-util-1.1.2.tgz",
+          "integrity": "sha1-8u6AdqmuPq4uZWcuRqIgB0+i3/M="
+        }
+      }
+    },
+    "raptor-regexp": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/raptor-regexp/-/raptor-regexp-1.0.1.tgz",
+      "integrity": "sha1-7PD2bGZxwM2fXkjDcFAmxVCZlcA="
+    },
+    "raptor-strings": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/raptor-strings/-/raptor-strings-1.0.2.tgz",
+      "integrity": "sha1-ks4ssBU6/pBHDYA5oCVbTPM6tfw=",
+      "requires": {
+        "raptor-polyfill": "1.0.2"
+      }
+    },
+    "raptor-util": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/raptor-util/-/raptor-util-3.2.0.tgz",
+      "integrity": "sha1-I7DIA8jxrIocrmfZpjiLSRYcl1g="
+    },
+    "resolve-from": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
+      "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c="
+    },
+    "rusha": {
+      "version": "0.8.11",
+      "resolved": "https://registry.npmjs.org/rusha/-/rusha-0.8.11.tgz",
+      "integrity": "sha1-yqiWOx2/0inZBibdPyp4RDDWBY0="
+    },
+    "shorthash": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/shorthash/-/shorthash-0.0.2.tgz",
+      "integrity": "sha1-WbJo7sveWQOLMNogK8+93rLEpOs="
+    },
+    "shot": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/shot/-/shot-4.0.4.tgz",
+      "integrity": "sha512-V8wHSJSNqt8ZIgdbTQCFIrp5BwBH+tsFLNBL1REmkFN/0PJdmzUBQscZqsbdSvdLc+Qxq7J5mcwzai66vs3ozA==",
+      "requires": {
+        "hoek": "5.0.2",
+        "joi": "13.1.0"
+      }
+    },
+    "simple-sha1": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/simple-sha1/-/simple-sha1-2.1.0.tgz",
+      "integrity": "sha1-lCe7lv8SY8wQqEFM7dUaGLkZ6LM=",
+      "requires": {
+        "rusha": "0.8.11"
+      }
+    },
+    "source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "optional": true
+    },
+    "stackframe": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.0.4.tgz",
+      "integrity": "sha512-to7oADIniaYwS3MhtCa/sQhrxidCCQiF/qp4/m5iN3ipf0Y7Xlri0f6eG29r08aL7JYl8n32AF3Q5GYBZ7K8vw=="
+    },
+    "statehood": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/statehood/-/statehood-6.0.5.tgz",
+      "integrity": "sha512-HPa8qT5sGTBVn1Fc9czBYR1oo7gBaay3ysnb04cvcF80YrDIV7880KpjmMj54j7CrFuQFfgMRb44QCRxRmAdTg==",
+      "requires": {
+        "boom": "7.1.1",
+        "bounce": "1.2.0",
+        "cryptiles": "4.1.1",
+        "hoek": "5.0.2",
+        "iron": "5.0.4",
+        "joi": "13.1.0"
+      }
+    },
+    "strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+    },
+    "subtext": {
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/subtext/-/subtext-6.0.7.tgz",
+      "integrity": "sha512-IcJUvRjeR+NB437Iq+LORFNJW4L6Knqkj3oQrBrkdhIaS2VKJvx/9aYEq7vi+PEx5/OuehOL/40SkSZotLi/MA==",
+      "requires": {
+        "boom": "7.1.1",
+        "content": "4.0.3",
+        "hoek": "5.0.2",
+        "pez": "4.0.1",
+        "wreck": "14.0.2"
+      }
+    },
+    "teamwork": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/teamwork/-/teamwork-3.0.1.tgz",
+      "integrity": "sha512-hEkJIpDOfOYe9NYaLFk00zQbzZeKNCY8T2pRH3I13Y1mJwxaSQ6NEsjY5rCp+11ezCiZpWGoGFTbOuhg4qKevQ=="
+    },
+    "topo": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/topo/-/topo-3.0.0.tgz",
+      "integrity": "sha512-Tlu1fGlR90iCdIPURqPiufqAlCZYzLjHYVVbcFWDMcX7+tK8hdZWAfsMrD/pBul9jqHHwFjNdf1WaxA9vTRRhw==",
+      "requires": {
+        "hoek": "5.0.2"
+      }
+    },
+    "try-require": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/try-require/-/try-require-1.2.1.tgz",
+      "integrity": "sha1-NEiaLKwMCcHMEO2RugEVlNQzO+I="
+    },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "requires": {
+        "prelude-ls": "1.1.2"
+      }
+    },
+    "type-detect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
+      "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI="
+    },
+    "vise": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/vise/-/vise-3.0.0.tgz",
+      "integrity": "sha512-kBFZLmiL1Vm3rHXphkhvvAcsjgeQXRrOFCbJb0I50YZZP4HGRNH+xGzK3matIMcpbsfr3I02u9odj4oCD0TWgA==",
+      "requires": {
+        "hoek": "5.0.2"
+      }
+    },
+    "vision": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/vision/-/vision-5.3.0.tgz",
+      "integrity": "sha512-IbQDInwjvg1t0tc2cQmZLJ0revybzmAymSP37MFyb2aXxQMPg1ItaPRY4vy5lM61wfkqEXKfhrwhltFqB90Qag==",
+      "requires": {
+        "boom": "7.1.1",
+        "hoek": "5.0.2",
+        "items": "2.1.1",
+        "joi": "13.1.0"
+      }
+    },
+    "warp10": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/warp10/-/warp10-1.3.6.tgz",
+      "integrity": "sha512-7cijX+NprqPV+UGUZXZw1I15JFHPqoy65tNVvP6cL43Vlanpcm8hBYoQTuDYUHa5x90Bct4gHhRtqqOOkLhQkw=="
+    },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+    },
+    "wreck": {
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/wreck/-/wreck-14.0.2.tgz",
+      "integrity": "sha512-QCm3omWNJUseqrSzwX2QZi1rBbmCfbFHJAXputLLyZ37VSiFnSYQB0ms/mPnSvrlIu7GVm89Y/gBNhSY26uVIQ==",
+      "requires": {
+        "boom": "7.1.1",
+        "hoek": "5.0.2"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   },
   "homepage": "https://github.com/marko-js-samples/marko-hapi#readme",
   "dependencies": {
-    "hapi": "^16.1.1",
-    "marko": "^4.2.8"
+    "hapi": "^17.2.0",
+    "marko": "^4.7.4",
+    "vision": "^5.3.0"
   }
 }

--- a/views/components/app-component/template.marko
+++ b/views/components/app-component/template.marko
@@ -1,0 +1,1 @@
+<h3>I am a ${data.name} ${data.message}</h3>

--- a/views/footer.marko
+++ b/views/footer.marko
@@ -1,0 +1,1 @@
+<p>Here is the footer, ${input.name}</p>

--- a/views/index.marko
+++ b/views/index.marko
@@ -1,0 +1,8 @@
+import footer from './footer';
+
+<p>Hello ${input.name}! You have ${input.count} messages!</p>
+<ul if(input.colors && input.colors.length)>
+  <li style="color: ${color}" for(color in input.colors)>${color}</li>
+</ul>
+<app-component name="MarkoJS" message="component"></app-component>
+<include(footer) name=input.name/>


### PR DESCRIPTION
Hapi v17 has been a complete re-write of the previous version using async-await, no callbacks any more.
I re-wrote this simple example using the latest hapi and also added the hapi/vision plugin for rendering. 
I also extended the example to show how to use MarkoJS components. 